### PR TITLE
Use unified region local for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ cp terraform.tfvars.example terraform.tfvars
 # wp_fqdn         = "blog.example.com"
 # db_password     = "StrongPassword123!"
 # aws_profile     = "myprofile"
+# region          = "eu-west-3"   # optional, defaults to eu-west-3
 ```
 
 ## Deploy

--- a/helm.tf
+++ b/helm.tf
@@ -16,9 +16,9 @@ resource "helm_release" "aws_load_balancer_controller" {
   create_namespace = false
 
   values = [yamlencode({
-    clusterName    = module.eks.cluster_name
-    region         = var.aws_region
-    serviceAccount = {
+      clusterName    = module.eks.cluster_name
+      region         = local.effective_region
+      serviceAccount = {
       create = true
       name   = "aws-load-balancer-controller"
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "cluster_name" {
 
 output "region" {
   description = "AWS region used by this stack"
-  value       = var.aws_region
+  value       = local.effective_region
 }
 
 output "acm_certificate_arn" {

--- a/providers.tf
+++ b/providers.tf
@@ -9,9 +9,14 @@ terraform {
   }
 }
 
-# Accept either region or aws_region (to match your terraform.tfvars)
+# Determine final AWS region (region takes precedence over aws_region)
+locals {
+  effective_region = coalesce(var.region, var.aws_region, "eu-west-3")
+}
+
+# Use the calculated region for the AWS provider
 provider "aws" {
-  region  = coalesce(var.region, var.aws_region, "eu-west-3")
+  region  = local.effective_region
   profile = var.aws_profile
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,7 +1,7 @@
 # Fill these with your real values, then rename this file to terraform.tfvars
 
 # AWS basics (optional override of defaults)
-aws_region  = "eu-west-3"
+region      = "eu-west-3"
 aws_profile = "student20"
 
 # Existing network

--- a/variables.tf
+++ b/variables.tf
@@ -6,13 +6,13 @@ variable "aws_profile" {
 }
 
 variable "region" {
-  description = "Preferred AWS region. If empty, aws_region may be used."
+  description = "AWS region for all resources. If unset, aws_region (deprecated) is used."
   type        = string
   default     = ""
 }
 
 variable "aws_region" {
-  description = "Legacy/alternate region (present in terraform.tfvars). Used when region is empty."
+  description = "DEPRECATED: fallback AWS region for backward compatibility. Use region instead."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- compute a single `effective_region` local and reuse it across providers
- reference `effective_region` in outputs and Helm ALB controller configuration
- clarify region variables and documentation for unified region input

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dac4d2d883249ff9026261cf8799